### PR TITLE
Quotations are the wrong way round

### DIFF
--- a/_extensions/quarto-thesis/partials/before-body.tex
+++ b/_extensions/quarto-thesis/partials/before-body.tex
@@ -84,11 +84,11 @@ $if(thesis.quotation)$
 \vspace*{0.2\textheight}
 
 $if(thesis.quotation.text)$
-\noindent"{\itshape $thesis.quotation.text$}"\bigbreak
+\noindent``{\itshape $thesis.quotation.text$}''\bigbreak
 
 \hfill $thesis.quotation.attribution$
 $else$
-\input{"$thesis.quotation$"}
+\input{``$thesis.quotation$''}
 $endif$
 
 $endif$


### PR DESCRIPTION
It's a quirk of LaTeX. See

https://tex.stackexchange.com/questions/52351/quote-marks-are-backwards-using-texmaker-pdflatex
